### PR TITLE
add links to the load error box

### DIFF
--- a/src/WebModel.h
+++ b/src/WebModel.h
@@ -56,6 +56,16 @@ struct ComboBoxCtrl : public Ctrl {
 };
 
 
+juce::String resolveSpaceUrl(juce::String urlOrName) {
+  if (urlOrName.contains("localhost") || urlOrName.contains("huggingface.co") || urlOrName.contains("http")) {
+    // do nothing! the url is already valid
+  }
+  else {
+      DBG("HARPProcessorEditor::buttonClicked: spaceUrl is not a valid url");
+      urlOrName = "https://huggingface.co/spaces/" + urlOrName;
+  }
+  return urlOrName;
+}
 
 using CtrlList = std::vector<std::pair<juce::Uuid, std::shared_ptr<Ctrl>>>;
 
@@ -112,6 +122,10 @@ public:
 
   bool ready() const override { return m_loaded; }
   std::string space_url() const { return m_url; }
+
+  juce::File getLogFile() const {
+    return m_logger->getLogFile();
+  }
 
   void load(const map<string, any> &params) override {
     m_ctrls.clear();


### PR DESCRIPTION
this PR let's us open the HARP logs // checking the HF space with the press of a button on the error box: 
<img width="655" alt="Screenshot 2024-06-03 at 1 12 13 PM" src="https://github.com/TEAMuP-dev/HARP/assets/55194054/36a34950-0e59-443a-8edd-4d1b0c2c0b00">

Fixes #139 
