### PR TITLE
Replace std::system

### DIFF
--- a/cmake/gradio_client.cmake
+++ b/cmake/gradio_client.cmake
@@ -33,7 +33,7 @@ endif()
 set(PYINSTALLER_COMMANDS 
     "${PYTHON_EXECUTABLE} -m ensurepip --upgrade"
     "${PYTHON_EXECUTABLE} -m pip install -r ${CMAKE_SOURCE_DIR}/py/client/requirements.txt"
-    "${PYINSTALLER_EXECUTABLE} -y gradiojuce_client.py --collect-all gradio_client"
+    "${PYINSTALLER_EXECUTABLE} --hide-console hide-early -y gradiojuce_client.py --collect-all gradio_client"
 )
 
 # Execute each command individually, and check the result of each

--- a/src/MainComponent.h
+++ b/src/MainComponent.h
@@ -304,7 +304,7 @@ private:
     {
         currentPositionMarker.setVisible (transportSource.isPlaying() || isMouseButtonDown());
 
-        currentPositionMarker.setRectangle (Rectangle<float> (timeToX (transportSource.getCurrentPosition()) - 0.75f, 0,
+        currentPositionMarker.setRectangle (juce::Rectangle<float> (timeToX (transportSource.getCurrentPosition()) - 0.75f, 0,
                                                               1.5f, (float) (getHeight() - scrollbar.getHeight())));
     }
 };

--- a/src/WebModel.h
+++ b/src/WebModel.h
@@ -169,10 +169,6 @@ public:
             .getChildFile("control_spec.json");
     outputPath.deleteFile();
 
-    // juce::File tempLogFile =
-    // juce::File::getSpecialLocation(juce::File::tempDirectory)
-    //     .getChildFile("system_get_ctrls_log.txt");
-    // tempLogFile.deleteFile();  // ensure the file doesn't already exist
 
     std::string command = (
       prefix_cmd
@@ -397,10 +393,6 @@ public:
       throw std::runtime_error("Failed to save controls to file.");
     }
 
-    // juce::File tempLogFile =
-    //     juce::File::getSpecialLocation(juce::File::tempDirectory)
-    //         .getChildFile("system_log" + randomString + ".txt");
-    // tempLogFile.deleteFile();  // ensure the file doesn't already exist
 
     std::string command = (
         prefix_cmd
@@ -442,8 +434,6 @@ public:
 
         message += "\n Check the logs " + m_logger->getLogFile().getFullPathName().toStdString() + " for more details.";
     }
-
-    // tempLogFile.deleteFile();  // delete the temporary log file
 
     // move the temp output file to the original input file
     tempOutputFile.moveFileTo(filetoProcess);

--- a/src/WebModel.h
+++ b/src/WebModel.h
@@ -182,6 +182,7 @@ public:
 
     juce::String logContent = cmd_result.first;
     juce::uint32 result = cmd_result.second;
+    LogAndDBG(logContent);
 
     if (result != 0) {
         // read the text from the temp log file.
@@ -407,6 +408,7 @@ public:
 
     juce::String logContent = cmd_result.first;
     juce::uint32 result = cmd_result.second;
+    LogAndDBG(logContent);
 
     if (result != 0) {
         // read the text from the temp log file.

--- a/src/WebModel.h
+++ b/src/WebModel.h
@@ -11,10 +11,6 @@
 
 #include <fstream>
 
-#if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
-  #include <windows.h>
-#endif
-
 
 #include "Model.h"
 


### PR DESCRIPTION
Addresses #170 and #172 by replacing std::system with juce::ChildProcess. cmd window no longer appears on Windows, and allows output to go to a juce::String so a temp log file is no longer necessary.

Minor bug: On MacOS a ValueError (i.e. for a build failure on HuggingFace) sometimes returns status code 0 still, so failure does not include the error message.