### PR TITLE
fix waveform thumbnail

### DIFF
--- a/src/media/MediaDisplayComponent.h
+++ b/src/media/MediaDisplayComponent.h
@@ -353,7 +353,8 @@ private:
     void timerCallback() override
     {
         if (isPlaying()) {
-            updateVisibleRange(visibleRange.movedToStartAt(getPlaybackPosition() - (visibleRange.getLength() / 2.0f)));
+            //updateVisibleRange(visibleRange.movedToStartAt(getPlaybackPosition() - (visibleRange.getLength() / 2.0f)));
+            updateVisibleRange(visibleRange);
         } else {
             stop();
             sendChangeMessage();


### PR DESCRIPTION
To increase legibility, turns off thumbnail auto-scrolling to keep thumbnail fixed in time, while playhead still moves. Clicking to move playhead still works, although it appears that the recently merged PRs now prevent clicking to move the playhead while in the "play" state (this only works in the "stop" state).