### PR TITLE
Save As Fixes

### DIFF
--- a/src/MainComponent.h
+++ b/src/MainComponent.h
@@ -329,6 +329,7 @@ public:
                             // Update any necessary internal state
                             // currentAudioFile = AudioFile(newFile); // Assuming a wrapper, adjust accordingly
                             DBG("File successfully saved as " << newFile.getFullPathName());
+                            loadMediaDisplay(newFile);
                         } else {
                             // Inform the user of failure
                             AlertWindow::showMessageBoxAsync(

--- a/src/MainComponent.h
+++ b/src/MainComponent.h
@@ -307,37 +307,56 @@ public:
     
     void saveAsCallback() {
         if (mediaDisplay->isFileLoaded()) {
+            StringArray validExtensions = mediaDisplay->getInstanceExtensions();
+            String filePatternsAllowed = "*" + validExtensions.joinIntoString(";*");
+            saveFileBrowser = std::make_unique<FileChooser>(
+                "Select a media file...", 
+                File(), 
+                filePatternsAllowed);
             // Launch the file chooser dialog asynchronously
-            fileBrowser->launchAsync(
+            saveFileBrowser->launchAsync(
                 FileBrowserComponent::saveMode | FileBrowserComponent::canSelectFiles,
                 [this](const FileChooser& browser)
                 {
+                    StringArray validExtensions = mediaDisplay->getInstanceExtensions();
                     File newFile = browser.getResult();
                     if (newFile != File{}) {
-                        URL tempFilePath = mediaDisplay->getTempFilePath();
+                        if (newFile.getFileExtension().compare("") == 0) {
+                            newFile = newFile.withFileExtension(validExtensions[0]);
+                        }
+                        if (validExtensions.contains(newFile.getFileExtension())) {
+                            URL tempFilePath = mediaDisplay->getTempFilePath();
 
-                        // Attempt to save the file to the new location
-                        bool saveSuccessful = tempFilePath.getLocalFile().copyFileTo(newFile);
-                        if (saveSuccessful) {
-                            // Inform the user of success
-                            AlertWindow::showMessageBoxAsync(
-                                AlertWindow::InfoIcon,
-                                "Save As",
-                                "File successfully saved as:\n" + newFile.getFullPathName(),
-                                "OK");
+                            // Attempt to save the file to the new location
+                            bool saveSuccessful = tempFilePath.getLocalFile().copyFileTo(newFile);
+                            if (saveSuccessful) {
+                                // Inform the user of success
+                                AlertWindow::showMessageBoxAsync(
+                                    AlertWindow::InfoIcon,
+                                    "Save As",
+                                    "File successfully saved as:\n" + newFile.getFullPathName(),
+                                    "OK");
 
-                            // Update any necessary internal state
-                            // currentAudioFile = AudioFile(newFile); // Assuming a wrapper, adjust accordingly
-                            DBG("File successfully saved as " << newFile.getFullPathName());
-                            loadMediaDisplay(newFile);
+                                // Update any necessary internal state
+                                // currentAudioFile = AudioFile(newFile); // Assuming a wrapper, adjust accordingly
+                                DBG("File successfully saved as " << newFile.getFullPathName());
+                                loadMediaDisplay(newFile);
+                            } else {
+                                // Inform the user of failure
+                                AlertWindow::showMessageBoxAsync(
+                                    AlertWindow::WarningIcon,
+                                    "Save As Failed",
+                                    "Failed to save file as:\n" + newFile.getFullPathName(),
+                                    "OK");
+                                DBG("Failed to save file as " << newFile.getFullPathName());
+                            }
                         } else {
                             // Inform the user of failure
                             AlertWindow::showMessageBoxAsync(
                                 AlertWindow::WarningIcon,
                                 "Save As Failed",
-                                "Failed to save file as:\n" + newFile.getFullPathName(),
+                                "Can't save file with extension " + newFile.getFileExtension() + " \n Valid extensions are: " + validExtensions.joinIntoString(";"),
                                 "OK");
-                            DBG("Failed to save file as " << newFile.getFullPathName());
                         }
                     } else {
                         DBG("Save As operation was cancelled by the user.");
@@ -977,12 +996,12 @@ public:
 
         String filePatternsAllowed = "*" + allExtensions.joinIntoString(";*");
 
-        fileBrowser = std::make_unique<FileChooser>(
+        openFileBrowser = std::make_unique<FileChooser>(
             "Select a media file...", 
             File(), 
             filePatternsAllowed);
 
-        fileBrowser->launchAsync(
+        openFileBrowser->launchAsync(
             FileBrowserComponent::openMode | FileBrowserComponent::canSelectFiles,
             [this](const FileChooser& browser)
             {
@@ -1200,7 +1219,8 @@ private:
     // the model itself
     std::shared_ptr<WebModel> model {new WebModel()};
 
-    std::unique_ptr<FileChooser> fileBrowser;
+    std::unique_ptr<FileChooser> openFileBrowser;
+    std::unique_ptr<FileChooser> saveFileBrowser;
 
     std::unique_ptr<MediaDisplayComponent> mediaDisplay;
 

--- a/src/media/AudioDisplayComponent.h
+++ b/src/media/AudioDisplayComponent.h
@@ -55,6 +55,11 @@ public:
         return extensions;
     }
 
+    StringArray getInstanceExtensions()
+    {
+        return AudioDisplayComponent::getSupportedExtensions();
+    }
+
     void loadMediaFile(const URL& filePath) override
     {
         const auto source = std::make_unique<URLInputSource>(filePath);

--- a/src/media/MediaDisplayComponent.h
+++ b/src/media/MediaDisplayComponent.h
@@ -33,6 +33,8 @@ public:
 
     virtual void drawMainArea(Graphics& g, Rectangle<int>& a) = 0;
 
+    virtual StringArray getInstanceExtensions() = 0;
+
     void paint(Graphics& g) override
     {
         g.fillAll(Colours::darkgrey);

--- a/src/media/MidiDisplayComponent.h
+++ b/src/media/MidiDisplayComponent.h
@@ -40,6 +40,11 @@ public:
         return extensions;
     }
 
+    StringArray getInstanceExtensions()
+    {
+        return MidiDisplayComponent::getSupportedExtensions();
+    }
+
     void loadMediaFile(const URL& filePath) override
     {
         // Create the local file this URL points to


### PR DESCRIPTION
Updates to the save as functionality. Doing a save as without a file extension will autofill a default (.wav or .mid), and saving with an unsupported extension will throw an error (addresses #184). Save as will update the currently viewed file so that later saves will go to the correct location (addresses #191). Save as also now uses a different file browser than open, which both allows more specificity on what extensions to allow (such that MacOS will now natively reject an improper extension), and prevents a crash when trying to do save as before open (addresses #193).

Tested on Windows 10, Ubuntu 20.04, and MacOS 14.5 (ARM).