### PR TITLE
Remove temp file on cancel

### DIFF
--- a/src/MainComponent.h
+++ b/src/MainComponent.h
@@ -847,6 +847,9 @@ public:
     {
         DBG("HARPProcessorEditor::buttonClicked cancel button listener activated");
         model->cancel();
+        // We already added a temp file, so we need to undo that
+        mediaDisplay->iteratePreviousTempFile();
+        mediaDisplay->clearFutureTempFiles();
         processCancelButton.setEnabled(false);
     }
     

--- a/src/media/MediaDisplayComponent.h
+++ b/src/media/MediaDisplayComponent.h
@@ -171,6 +171,13 @@ public:
         }
     }
 
+    void clearFutureTempFiles()
+    {
+        int n = tempFilePaths.size() - (currentTempFileIdx + 1);
+
+        tempFilePaths.removeLast(n);
+    }
+
     void overwriteTarget()
     {
         // Overwrite the original file - necessary for seamless sample editing integration
@@ -335,13 +342,6 @@ private:
     virtual void resetDisplay() = 0;
 
     virtual void postLoadActions(const URL& filePath) = 0;
-
-    void clearFutureTempFiles()
-    {
-        int n = tempFilePaths.size() - (currentTempFileIdx + 1);
-
-        tempFilePaths.removeLast(n);
-    }
 
     void updateCursorPosition()
     {


### PR DESCRIPTION
Addresses #200 . This does move the `clearFutureTempFiles` method of `MediaDisplayComponent` from private to public, not sure if anyone would have any qualms with that.