### PR TITLE
Don't reset model on custom path cancel

### DIFF
--- a/src/MainComponent.h
+++ b/src/MainComponent.h
@@ -811,7 +811,7 @@ public:
 
                     } else { // Cancel was clicked or the window was closed
                         DBG("Custom path entry was canceled.");
-                        resetModelPathComboBox();
+                        // resetModelPathComboBox();
                     }
                     delete customPathWindow;
                 }), true);


### PR DESCRIPTION
Addresses #168 . Just had to comment out one line, was there a reason that this was necessary? I don't see any behavior that is lost by not resetting the model path combo box.