### PR TITLE
Fixed bad undo/save state after canceling.

### DIFF
--- a/src/MainComponent.h
+++ b/src/MainComponent.h
@@ -994,17 +994,16 @@ public:
     void cancelCallback()
     {
         DBG("HARPProcessorEditor::buttonClicked cancel button listener activated");
+
         OpResult cancelResult = model->cancel();
+
         if (cancelResult.failed())
         {
-            // This "if" block hasn't been tested
-
             LogAndDBG(cancelResult.getError().devMessage.toStdString());
             AlertWindow::showMessageBoxAsync(AlertWindow::WarningIcon,
                                              "Cancel Error",
                                              "An error occurred while cancelling the processing: \n"
                                                  + cancelResult.getError().devMessage);
-            resetProcessingButtons();
             return;
         }
         // Update current process to empty
@@ -1015,9 +1014,8 @@ public:
         // We already added a temp file, so we need to undo that
         mediaDisplay->iteratePreviousTempFile();
         mediaDisplay->clearFutureTempFiles();
-        // Should we restore back to process???
-        processCancelButton.setMode(processButtonInfo.label);
-        processCancelButton.setEnabled(true);
+
+        resetProcessingButtons();
     }
 
     void processCallback()


### PR DESCRIPTION
Due to a very simple mistake, HARP was placed into a bad state after the cancel operation where the undo and save operations were disabled.

This PR also makes it such that if cancellation fails, HARP remains in the processing state and the cancel button is re-enabled.