### PR TITLE
Fix for labels on windows

### DIFF
--- a/src/media/MediaDisplayComponent.cpp
+++ b/src/media/MediaDisplayComponent.cpp
@@ -1,5 +1,4 @@
 #include "MediaDisplayComponent.h"
-#include "../HarpLogger.h"
 
 MediaDisplayComponent::MediaDisplayComponent()
 {
@@ -524,7 +523,6 @@ void MediaDisplayComponent::addOverheadLabel(OverheadLabelComponent* l)
 
 void MediaDisplayComponent::clearLabels(int processingIdxCutoff)
 {
-    LogAndDBG("Starting clear labels");
     for (int i = labelOverlays.size() - 1; i >= 0; --i)
     {
         LabelOverlayComponent* l = labelOverlays[i];

--- a/src/media/MediaDisplayComponent.h
+++ b/src/media/MediaDisplayComponent.h
@@ -105,10 +105,10 @@ public:
     void addLabels(LabelList& labels);
     void clearLabels(int processingIdxCutoff = 0);
 
-    void addLabelOverlay(LabelOverlayComponent l);
+    void addLabelOverlay(LabelOverlayComponent* l);
     void removeLabelOverlay(LabelOverlayComponent* l);
 
-    void addOverheadLabel(OverheadLabelComponent l);
+    void addOverheadLabel(OverheadLabelComponent* l);
     void removeOverheadLabel(OverheadLabelComponent* l);
 
     int getNumOverheadLabels();
@@ -174,6 +174,6 @@ private:
 
     double currentHorizontalZoomFactor;
 
-    Array<LabelOverlayComponent*> labelOverlays;
-    Array<OverheadLabelComponent*> overheadLabels;
+    OwnedArray<LabelOverlayComponent> labelOverlays;
+    OwnedArray<OverheadLabelComponent> overheadLabels;
 };


### PR DESCRIPTION
Switched labelOverlays and overheadLabels to OwnedArrays to fix memory leak on Windows.

Tested on Windows and Linux